### PR TITLE
Always enable gpgcheck, skip repos, add type to rawhide .repo too

### DIFF
--- a/rpmfusion-free-rawhide.repo
+++ b/rpmfusion-free-rawhide.repo
@@ -3,7 +3,8 @@ name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=http://download1.rpmfusion.org/free/fedora/development/$basearch/os/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide&arch=$basearch
 enabled=1
-gpgcheck=0
+gpgcheck=1
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-rawhide
 
 [rpmfusion-free-rawhide-debuginfo]
@@ -13,7 +14,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide-debug&a
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-rawhide
 
 [rpmfusion-free-rawhide-source]
@@ -23,6 +24,6 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide-source&
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-rawhide
 

--- a/rpmfusion-free-rawhide.repo
+++ b/rpmfusion-free-rawhide.repo
@@ -4,6 +4,7 @@ name=RPM Fusion for Fedora Rawhide - Free
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide&arch=$basearch
 enabled=1
 skip_if_unavailable=1
+type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-rawhide

--- a/rpmfusion-free-rawhide.repo
+++ b/rpmfusion-free-rawhide.repo
@@ -3,6 +3,7 @@ name=RPM Fusion for Fedora Rawhide - Free
 #baseurl=http://download1.rpmfusion.org/free/fedora/development/$basearch/os/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide&arch=$basearch
 enabled=1
+skip_if_unavailable=1
 gpgcheck=1
 repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-latest file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-rawhide
@@ -12,6 +13,7 @@ name=RPM Fusion for Fedora Rawhide - Free - Debug
 #baseurl=http://download1.rpmfusion.org/free/fedora/development/$basearch/os/debug/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide-debug&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -22,6 +24,7 @@ name=RPM Fusion for Fedora Rawhide - Free - Source
 #baseurl=http://download1.rpmfusion.org/free/fedora/development/source/SRPMS/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-rawhide-source&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-free-updates-testing.repo
+++ b/rpmfusion-free-updates-testing.repo
@@ -5,7 +5,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-testing
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-testing-debuginfo]
@@ -15,7 +15,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-testing
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-testing-source]
@@ -25,6 +25,6 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-testing
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 

--- a/rpmfusion-free-updates-testing.repo
+++ b/rpmfusion-free-updates-testing.repo
@@ -3,6 +3,7 @@ name=RPM Fusion for Fedora $releasever - Free - Test Updates
 #baseurl=http://download1.rpmfusion.org/free/fedora/updates/testing/$releasever/$basearch/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-testing-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -13,6 +14,7 @@ name=RPM Fusion for Fedora $releasever - Free - Test Updates Debug
 #baseurl=http://download1.rpmfusion.org/free/fedora/updates/testing/$releasever/$basearch/debug/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-testing-debug-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -23,6 +25,7 @@ name=RPM Fusion for Fedora $releasever - Free - Test Updates Source
 #baseurl=http://download1.rpmfusion.org/free/fedora/updates/testing/$releasever/SRPMS/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-testing-source-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-free-updates.repo
+++ b/rpmfusion-free-updates.repo
@@ -3,6 +3,7 @@ name=RPM Fusion for Fedora $releasever - Free - Updates
 #baseurl=http://download1.rpmfusion.org/free/fedora/updates/$releasever/$basearch/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-released-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -13,6 +14,7 @@ name=RPM Fusion for Fedora $releasever - Free - Updates Debug
 #baseurl=http://download1.rpmfusion.org/free/fedora/updates/$releasever/$basearch/debug/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-released-debug-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -23,6 +25,7 @@ name=RPM Fusion for Fedora $releasever - Free - Updates Source
 #baseurl=http://download1.rpmfusion.org/free/fedora/updates/$releasever/SRPMS/
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-released-source-$releasever&arch=$basearch
 enabled=0
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-free-updates.repo
+++ b/rpmfusion-free-updates.repo
@@ -5,7 +5,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-release
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-debuginfo]
@@ -15,7 +15,7 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-release
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-updates-source]
@@ -25,6 +25,6 @@ metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-updates-release
 enabled=0
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 

--- a/rpmfusion-free.repo
+++ b/rpmfusion-free.repo
@@ -4,6 +4,7 @@ name=RPM Fusion for Fedora $releasever - Free
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-$releasever&arch=$basearch
 enabled=0
 metadata_expire=14d
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -15,6 +16,7 @@ name=RPM Fusion for Fedora $releasever - Free - Debug
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-debug-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1
@@ -26,6 +28,7 @@ name=RPM Fusion for Fedora $releasever - Free - Source
 metalink=https://mirrors.rpmfusion.org/metalink?repo=free-fedora-source-$releasever&arch=$basearch
 enabled=0
 metadata_expire=7d
+skip_if_unavailable=1
 type=rpm-md
 gpgcheck=1
 repo_gpgcheck=1

--- a/rpmfusion-free.repo
+++ b/rpmfusion-free.repo
@@ -6,7 +6,7 @@ enabled=0
 metadata_expire=14d
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-debuginfo]
@@ -17,7 +17,7 @@ enabled=0
 metadata_expire=7d
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 
 [rpmfusion-free-source]
@@ -28,6 +28,6 @@ enabled=0
 metadata_expire=7d
 type=rpm-md
 gpgcheck=1
-repo_gpgcheck=0
+repo_gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-rpmfusion-free-fedora-$releasever
 


### PR DESCRIPTION
1. There is no reason to ever disable gpgcheck, so please have and keep it enabled. `repo_gpgcheck` works fine, and an additional layer of protection would not be amiss.

2. Works around a bug (or feature) in dnf where it will not update any package if a single repo fails to download. RPMFusion mirrors have been offline in the past, though not for long.

3. I guess this was a mistake, that the rawhide repo is the only one missing the `type=rpm-md` option.

PS: How do I get these changes to the Fedora 26, 25, 24(?) repos? Do I need to do anything for that?